### PR TITLE
Fix the check-model step under SBCL.

### DIFF
--- a/BDD/mu-sbcl.lisp
+++ b/BDD/mu-sbcl.lisp
@@ -192,10 +192,17 @@
 ;;;;;;;;;;;;;;;;;;;
 
 ;;; LIST append_cont (void *p, LIST list)
-(sb-alien:define-alien-routine ("mu___append_cont" append_cont)
+(sb-alien:define-alien-routine ("mu___append_cont" append_cont_internal_alien)
 			       (* t)
   (p (* t))
   (list (* t)))
+(defun append_cont (p list)
+  (append_cont_internal_alien
+   (if (typep p '(UNSIGNED-BYTE 64))
+       (sb-alien:sap-alien (sb-sys:int-sap p) (* t))
+       p)
+   list))
+
 ;;; LIST empty_list (void)
 (sb-alien:define-alien-routine ("mu___empty_list" empty_list)
 			       (* t))

--- a/BDD/mu.lisp
+++ b/BDD/mu.lisp
@@ -1218,12 +1218,12 @@ time).  Verbose? set to T provides more information."
 (defun make-geq-bdd* (bdd-list num-rep)
   (if (consp num-rep)
       (if (consp (cdr num-rep))
-	  (if (= (car num-rep) (mu-mk-true))
+	  (if (equal (car num-rep) (mu-mk-true))
                (mu-mk-and  (mu-create-bool-var (car bdd-list)) 
                         (make-geq-bdd* (cdr bdd-list)(cdr num-rep)))
                (mu-mk-or (mu-create-bool-var (car bdd-list)) 
                         (make-geq-bdd* (cdr bdd-list)(cdr num-rep))))
-	  (if (= (car num-rep) (mu-mk-true))
+	  (if (equal (car num-rep) (mu-mk-true))
 	      (mu-create-bool-var  (car bdd-list))
 	      (mu-mk-true)))
       (mu-mk-true)))
@@ -1245,14 +1245,14 @@ time).  Verbose? set to T provides more information."
 (defun make-leq-bdd* (bdd-list num-rep)
   (if (consp num-rep)
       (if (consp (cdr num-rep))
-	  (if (= (car num-rep) (mu-mk-true))
+	  (if (equal (car num-rep) (mu-mk-true))
               (mu-mk-or
                     (mu-mk-not (mu-create-bool-var (car bdd-list)))
                        (make-leq-bdd* (cdr bdd-list)(cdr num-rep)))
               (mu-mk-and 
                     (mu-mk-not (mu-create-bool-var (car bdd-list)))
                        (make-leq-bdd* (cdr bdd-list)(cdr num-rep))))
-	  (if (= (car num-rep) (mu-mk-true))
+	  (if (equal (car num-rep) (mu-mk-true))
 	      (mu-mk-true)
 	      (mu-mk-not (mu-create-bool-var (car bdd-list)) )))
       (mu-mk-true)))
@@ -1610,14 +1610,21 @@ time).  Verbose? set to T provides more information."
 ;;
 ;;
 
+#+sbcl
+(defun check-null (ptr)
+  (sb-alien:null-alien ptr))
+
+#-sbcl
+(defun check-null (ptr)
+  (zerop ptr))
 
 (defun mu-translate-from-bdd-list (bddlist)
-  (let ((bdds (unless (zerop bddlist)
+  (let ((bdds (unless (check-null bddlist)
 		(mu-translate-from-bdd-list* (list_first bddlist)))))
     (mapcar #'mu-translate-bdd-cube bdds)))
 
 (defun mu-translate-from-bdd-list* (bddlist &optional result)
-  (if (zerop bddlist)
+  (if (check-null bddlist)
       (nreverse result)
       (mu-translate-from-bdd-list*
        (list_next bddlist)


### PR DESCRIPTION
Fix various problem with the check-model step when PVS is compiled against
SBCL:
 - Wrap the mu___append_cont so that 32bit numbers are converted to pointers.
Otherwise SBCL throws type errors.  To avoid compatibility issues, the alien
interface isn't changed.
 - Fix comparisons involving c pointers.
 - Properly check for null pointers, using an implementation proper way.  SBCL
requires a proper null check instead of just comparing the pointer to zero.

Note I only tried running this under SBCL.  Except for the check-null function, I don't think anything else should be broken.