### PR TITLE
Fix PVS when compiling against SBCL 1.2.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ compiler:
 
 env:
   matrix:
+    - SBCL_VERSION=1.2.3
     - SBCL_VERSION=1.2.1
     - SBCL_VERSION=1.1.18
     - SBCL_VERSION=1.0.58

--- a/BDD/mu-sbcl.lisp
+++ b/BDD/mu-sbcl.lisp
@@ -192,10 +192,17 @@
 ;;;;;;;;;;;;;;;;;;;
 
 ;;; LIST append_cont (void *p, LIST list)
-(sb-alien:define-alien-routine ("mu___append_cont" append_cont)
+(sb-alien:define-alien-routine ("mu___append_cont" append_cont_internal_alien)
 			       (* t)
   (p (* t))
   (list (* t)))
+(defun append_cont (p list)
+  (append_cont_internal_alien
+   (if (typep p '(UNSIGNED-BYTE 64))
+       (sb-alien:sap-alien (sb-sys:int-sap p) (* t))
+       p)
+   list))
+
 ;;; LIST empty_list (void)
 (sb-alien:define-alien-routine ("mu___empty_list" empty_list)
 			       (* t))

--- a/BDD/mu.lisp
+++ b/BDD/mu.lisp
@@ -1218,12 +1218,12 @@ time).  Verbose? set to T provides more information."
 (defun make-geq-bdd* (bdd-list num-rep)
   (if (consp num-rep)
       (if (consp (cdr num-rep))
-	  (if (= (car num-rep) (mu-mk-true))
+	  (if (equal (car num-rep) (mu-mk-true))
                (mu-mk-and  (mu-create-bool-var (car bdd-list)) 
                         (make-geq-bdd* (cdr bdd-list)(cdr num-rep)))
                (mu-mk-or (mu-create-bool-var (car bdd-list)) 
                         (make-geq-bdd* (cdr bdd-list)(cdr num-rep))))
-	  (if (= (car num-rep) (mu-mk-true))
+	  (if (equal (car num-rep) (mu-mk-true))
 	      (mu-create-bool-var  (car bdd-list))
 	      (mu-mk-true)))
       (mu-mk-true)))
@@ -1245,14 +1245,14 @@ time).  Verbose? set to T provides more information."
 (defun make-leq-bdd* (bdd-list num-rep)
   (if (consp num-rep)
       (if (consp (cdr num-rep))
-	  (if (= (car num-rep) (mu-mk-true))
+	  (if (equal (car num-rep) (mu-mk-true))
               (mu-mk-or
                     (mu-mk-not (mu-create-bool-var (car bdd-list)))
                        (make-leq-bdd* (cdr bdd-list)(cdr num-rep)))
               (mu-mk-and 
                     (mu-mk-not (mu-create-bool-var (car bdd-list)))
                        (make-leq-bdd* (cdr bdd-list)(cdr num-rep))))
-	  (if (= (car num-rep) (mu-mk-true))
+	  (if (equal (car num-rep) (mu-mk-true))
 	      (mu-mk-true)
 	      (mu-mk-not (mu-create-bool-var (car bdd-list)) )))
       (mu-mk-true)))
@@ -1610,14 +1610,21 @@ time).  Verbose? set to T provides more information."
 ;;
 ;;
 
+#+sbcl
+(defun check-null (ptr)
+  (sb-alien:null-alien ptr))
+
+#-sbcl
+(defun check-null (ptr)
+  (zerop ptr))
 
 (defun mu-translate-from-bdd-list (bddlist)
-  (let ((bdds (unless (zerop bddlist)
+  (let ((bdds (unless (check-null bddlist)
 		(mu-translate-from-bdd-list* (list_first bddlist)))))
     (mapcar #'mu-translate-bdd-cube bdds)))
 
 (defun mu-translate-from-bdd-list* (bddlist &optional result)
-  (if (zerop bddlist)
+  (if (check-null bddlist)
       (nreverse result)
       (mu-translate-from-bdd-list*
        (list_next bddlist)

--- a/src/prover/strategies.lisp
+++ b/src/prover/strategies.lisp
@@ -446,7 +446,8 @@
 	      (consp (car sexp))
 	      (eq (caar sexp) 'quote)
 	      (symbolp (cadar sexp))
-	      (assq (rule-rawname (cadar sexp)) rules-inheritance))
+	      (assq (rule-rawname (cadar sexp)) rules-inheritance)
+	      (find-symbol "BACKQ-CONS" 'sb-impl)) ;;; TODO: Remove this branch when SBCL <1.2.2 is no longer supported.
 	 (let* ((rule (rule-rawname (cadar sexp)))
 		(formals (get-rule-formals rule))
 		(opts (get-&optional-args formals)))
@@ -479,15 +480,15 @@
        #+allegro 
        (eq (car sexp) 'excl::backquote)
        #+sbcl
-       (memq (car sexp) '(sb-impl::backq-cons sb-impl::backq-list))
+       (memq (car sexp) (list (find-symbol "BACKQ-CONS" `sb-impl) (find-symbol "BACKQ-LIST" `sb-impl))) ;;; TODO: Remove when SBCL <1.2.2 is no longer supported.
        #-(or allegro sbcl)
        (error "backquoted? not defined for this lisp")))
 
 (defun unbackquoted? (sexp)
-  (and (consp sexp)
+  (and #-allegro nil
+       (consp sexp)
        (memq (car sexp)
-	     #+allegro '(excl::bq-comma excl::bq-comma-atsign)
-	     #+sbcl '(sb-impl::backq-comma sb-impl::backq-comma-at))))
+	     #+allegro '(excl::bq-comma excl::bq-comma-atsign))))
 	   
 
 (defun rule-rawname (rule)
@@ -504,7 +505,7 @@
 			(list (keyword-arg-symbol ka)
 			      (if backquoted
 				  (list #+allegro 'excl::bq-comma
-					#+sbcl 'sb-impl::backq-comma
+					#+sbcl (find-symbol "BACKQ-COMMA" 'sb-impl) ;;; TODO: Remove when SBCL <1.2.2 is no longer supported.
 					(keyword-arg-symbol ka :pvs))
 				  (keyword-arg-symbol ka :pvs))))
 	      (remove-if


### PR DESCRIPTION
SBCL 1.2.2 has a patch that improves handling of the backquote operator.  This
change broke PVS's handling of said operator.  It appears that SBCL no longer
needs special handling of the backquote character, so just disable all such
branches on newer versions of SBCL, and leave a TODO comment for when SBCL
1.2.2+ is the new minimum version.

Also, SBCL never seemed to match the unbackquoted? branch.  So just remove
that code as it is dead anyways (leaving allegro in place).

Finally, bump travis to verify against 1.2.3 as well, since it has the patch.

Note: I didn't change the allegro side, as I don't have a copy to use myself.  But the unbackquoted branch may not work with them either, and could be removed.