### PR TITLE
Fix `working-directory` on SBCL to use canonical paths

### DIFF
--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -452,7 +452,7 @@ is replaced with replacement."
 
 #+sbcl
 (defun working-directory ()
-  (make-pathname :directory (sb-posix:getcwd)))
+  (truename (sb-posix:getcwd)))
 
 #+sbcl
 (defun set-working-directory (dir)


### PR DESCRIPTION
The original SBCL-specific version of `working-directory` was wrongly using the ANSI Common Lisp *make-pathname* function to transform a path string into a Common Lisp `pathname` object:
```
#+sbcl
(defun working-directory ()
  (make-pathname :directory (sb-posix:getcwd)))
```
In ANSI Common Lisp a call to `make-pathname` with the keyword argument `:directory` and a string is only defined if the string represents exclusively the name of a [top-level directory](http://www.lispworks.com/documentation/HyperSpec/Body/f_mk_pn.htm#make-pathname). This property is not enforced, for example, when *PVS* sets the *context-path* slot of a *theory* loaded from a binary file:
```
(defun get-theory-from-binfile (filename)
	...
	(setf (context-path theory) (working-directory))
	...
)
```
In SBCL the behaviour of `make-pathname` is to append and prepend a slash to the top level directory name, thus converting it into an absolute path string. Hence, the legacy `working-directory` executing in the `/Users/foo/pvslib/` directory would return the `//Users/foo/pvslib//` `pathname` object.

The problem comes when comparing if two `pathnames` are equal, as is done in:
```
(defmethod lib-datatype-or-theory? ((mod datatype-or-module))
  (assert (context-path mod))
  (and (not (equal (context-path mod) *default-pathname-defaults*))
       (not (from-prelude? mod)))
```
For example, if `(context-path mod)` returns `//Users/foo/pvslib//` and `*default-pathname-defaults*` is `/Users/foo/pvslib/` the function will return *true* but its intention should be to return *false*. In fact, the previous predicate is used as the condition for stopping recursion in the `parsed?*` method that is called during typechecking:
```
(defmethod parsed?* ((mod datatype-or-module))
  (or (memq mod *theories-seen*)
      (let ((prsd? (cond ((from-prelude? mod))
			 ((lib-datatype-or-theory? mod)  <------------------------
			  (with-workspace (context-path mod)
			    (parsed?* mod)))
			 ((generated-by mod)
			  (let ((gth (get-theory (generated-by mod))))
			    ;;(unless gth (break "parsed?*: ~a" (generated-by mod)))
			    (and gth
				 (or (parsed?* gth)
				     ;;(break "(parsed?* ~a) failed" gth)
				     ))))
			 (t (and (filename mod)
				 (eql (car (gethash (filename mod) (current-pvs-files)))
				      (file-write-date (make-specpath (filename mod)))))))))
	(push mod *theories-seen*)
	prsd?)))
```
The consequences of this propagation of erroneous information was that *PVS* would typecheck successfully when there were no cached binary files; but as soon as theories started to get loaded from binary files, `parsed?*` would loop indefinitely until the stack overflowed.

This fix avoids that infinite loop by storing the canonical name (in ANSI Common Lisp terms, the *truename*) of the working directory returned by the `working-directory` function.