### PR TITLE
Give the Theory Interpretations nodes unique names

### DIFF
--- a/doc/release-notes/pvs7.1-release-notes.texi
+++ b/doc/release-notes/pvs7.1-release-notes.texi
@@ -65,7 +65,7 @@ through Linux package managers, or using easy_install or pip.
 * Typepred Extension::
 * TCC Ordering::
 * Yices in 7.1::
-* Theory Interpretations::
+* Theory Interpretations in 7.1::
 @end menu
 
 @node PVS Workspaces
@@ -753,7 +753,7 @@ fixed.
 The yices prover commands have been fully integrated into PVS, and Yices
 versions 1 and 2 are included in the distribution.
 
-@node Theory Interpretations
+@node Theory Interpretations in 7.1
 @subsection Theory Interpretations
 
 Theory interpretations have been improved in a few ways.  First, if an


### PR DESCRIPTION
makeinfo complains:
```
./pvs5.0-release-notes.texi:112: @node `Theory Interpretations' previously defined
./pvs7.1-release-notes.texi:756: here is the previous definition as @node
./pvs7.1-release-notes.texi:756: warning: node `Expression Judgements' is next for `Theory Interpretations' in menu but not in sectioning
./pvs7.1-release-notes.texi:756: warning: node prev `Theory Interpretations' in menu `ProofLite' and in sectioning `Yices in 7.1' differ
./pvs7.1-release-notes.texi:756: warning: node up `Theory Interpretations' in menu `5.0 New Features' and in sectioning `7.1 New Features' differ
./pvs5.0-release-notes.texi:105: warning: node next `ProofLite' in menu `Theory Interpretations' and in sectioning `' differ
./pvs5.0-release-notes.texi:132: warning: node prev `Expression Judgements' in menu `Theory Interpretations' and in sectioning `' differ
make: *** [Makefile:22: pvs-release-notes.info] Error 1
```
The problem is that `pvs5.0-release-notes.texi` and `pvs7.1-release-notes.texi` both have a node named Theory Interpretations.  This commit changes the 7.1 version to have a unique node name.