### PR TITLE
Use xcrun to find location of macOS SDK.

### DIFF
--- a/src/BDD/arm-MacOSX/Makefile
+++ b/src/BDD/arm-MacOSX/Makefile
@@ -9,7 +9,8 @@ INCLUDES=-I/usr/include -I$(BDD) -I$(UTILS) -I$(MU)
 CFLAGS=-g -O2 -Wall -pedantic -std=gnu99 -mtune=native -mcpu=apple-a14 $(INCLUDES)
 XCFLAGS=-O2
 LD=ld
-LDFLAGS = -dylib -flat_namespace -undefined suppress -arch arm64 -platform_version macos 11.0.0 12.0 -L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+SDK=$(shell xcrun --show-sdk-path)
+LDFLAGS = -dylib -flat_namespace -undefined suppress -arch arm64 -platform_version macos 11.0.0 12.0 -L $(SDK)/usr/lib
 SHELL = /bin/sh
 VPATH = ..:../bdd/utils:../bdd/src:../mu/src
 

--- a/src/BDD/ix86-MacOSX/Makefile
+++ b/src/BDD/ix86-MacOSX/Makefile
@@ -6,7 +6,8 @@ INCLUDES = -I/usr/include -I$(BDD) -I$(UTILS) -I$(MU)
 # for both leopard and tiger
 MACOSX_DEPLOYMENT_TARGET=10.11
 LD = ld
-LDFLAGS = -bundle -flat_namespace -undefined suppress -L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+SDK=$(shell xcrun --show-sdk-path)
+LDFLAGS = -bundle -flat_namespace -undefined suppress -L $(SDK)/usr/lib
 CC = gcc
 CFLAGS = -dynamic -DNDEBUG -arch x86_64 $(INCLUDES)
 #CFLAGS = -dynamic -g -Wall -arch x86_64 $(INCLUDES)

--- a/src/WS1S/arm-MacOSX/Makefile
+++ b/src/WS1S/arm-MacOSX/Makefile
@@ -18,7 +18,8 @@ XCFLAGS = -O2
 # So there doesn't seem to be any choice.
 # 
 LD=ld
-LDFLAGS = -dylib -flat_namespace -undefined suppress -arch arm64 -platform_version macos 11.0.0 12.0  -L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+SDK=$(shell xcrun --show-sdk-path)
+LDFLAGS = -dylib -flat_namespace -undefined suppress -arch arm64 -platform_version macos 11.0.0 12.0  -L $(SDK)/usr/lib
 SHELL = /bin/sh
 VPATH = ..:../mona-1.4/BDD:../mona-1.4/DFA:../mona-1.4/Mem
 

--- a/src/WS1S/ix86-MacOSX/Makefile
+++ b/src/WS1S/ix86-MacOSX/Makefile
@@ -15,7 +15,8 @@ INCLUDES = -I$(BDD) -I$(DFA) -I$(UTILS)
 # 
 MACOSX_DEPLOYMENT_TARGET=10.11
 LD = ld
-LDFLAGS = -bundle -flat_namespace -undefined suppress -L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+SDK=$(shell xcrun --show-sdk-path)
+LDFLAGS = -bundle -flat_namespace -undefined suppress -L $(SDK)/usr/lib
 CC = gcc
 CFLAGS += -fPIC -dynamic -D_POSIX_SOURCE -DSYSV $(INCLUDES)
 XCFLAGS = -O2

--- a/src/utils/arm-MacOSX/Makefile
+++ b/src/utils/arm-MacOSX/Makefile
@@ -5,7 +5,8 @@ CC=clang
 # CFLAGS=-dynamic
 CFLAGS=-g -O2 -Wall -pedantic -std=gnu99 -mtune=native -mcpu=apple-a14
 LD=ld
-LDFLAGS = -dylib -flat_namespace -undefined suppress -arch arm64 -platform_version macos 11.0.0 12.0 -L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+SDK=$(shell xcrun --show-sdk-path)
+LDFLAGS = -dylib -flat_namespace -undefined suppress -arch arm64 -platform_version macos 11.0.0 12.0 -L $(SDK)/usr/lib
 WFLAGS=
 VPATH=..
 

--- a/src/utils/ix86-MacOSX/Makefile
+++ b/src/utils/ix86-MacOSX/Makefile
@@ -2,7 +2,8 @@
 # for both leopard and tiger
 MACOSX_DEPLOYMENT_TARGET=10.11
 LD=ld
-LDFLAGS = -bundle -flat_namespace -undefined suppress -L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+SDK=$(shell xcrun --show-sdk-path)
+LDFLAGS = -bundle -flat_namespace -undefined suppress -L $(SDK)/usr/lib
 CC=gcc
 CFLAGS=-dynamic
 WFLAGS=


### PR DESCRIPTION
The location of the SDK files depends on the OS version, so cannot be hardcoded into the Makefiles.  The build was failing for me on Monterey, but with this modification it now passes.

Tested on macOS 12.6.3 with Intel processor.  I've also included the corresponding modifications for the Arm makefiles, but am unable to test.
