### PR TITLE
Don't load user .emacs when batch processing during build.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -689,7 +689,7 @@ tar :
 $(PVSPATH)emacs/pvs-prelude-files-and-regions.el : \
                   $(PVSPATH)emacs/pvs-set-prelude-info.el \
                   $(PVSPATH)lib/prelude.pvs
-	-./pvs -batch -l emacs/pvs-set-prelude-info.el \
+	-./pvs -batch -q -l emacs/pvs-set-prelude-info.el \
                         -f set-prelude-files-and-regions
 
 # We need to create the elc files, but this does not work well with make, as
@@ -701,7 +701,7 @@ $(PVSPATH)emacs/.readme : $(emacs-src)
 	echo "File exists for make dependency usage" > $@
 
 $(emacs-elc) : $(PVSPATH)emacs/.readme
-	(cd emacs; $(EMACS) -batch -l pvs-byte-compile.el)
+	(cd emacs; $(EMACS) -batch -q -l pvs-byte-compile.el)
 
 install:
 	@echo "target install is not used for PVS - see INSTALL"


### PR DESCRIPTION
User code in the .emacs file can interfere with PVS build operations (as it did for me initially), so I think it's better not to load the user's .emacs if possible.

This might also be related to Issue #92, in that it's to do with code external to PVS causing problems.  I'm not familiar with the PVS installation process (so far I've only run PVS from the build directory), but maybe a "-q" is also appropriate in the install-sh script?
