### PR TITLE
Fix C errors for the SBCL-based ARM Mac build

### DIFF
--- a/src/BDD/bdd/utils/hash.h
+++ b/src/BDD/bdd/utils/hash.h
@@ -71,7 +71,7 @@ typedef struct HASHTAB {
   int nr_rehashes;		/* nr. rehashes */
   int primes_index;		/* curr. index in primes[] table */
 #ifdef ALLOW_REHASH
-  void (*rehash_function) ();	/* function called when non-NULL */
+  void (*rehash_function) (int, int);	/* function called when non-NULL */
 				/* to process change of entry */
 				/* when rehashing in process. */
 				/* Rehashing might happen upon lookup with */

--- a/src/BDD/bdd_table.c
+++ b/src/BDD/bdd_table.c
@@ -98,9 +98,9 @@ BDDPTR bdd___bdd_create_var_after (BDDPTR v) {return bdd_create_var_after (v);}
 BDDPTR bdd___bdd_create_var_last (void) {return bdd_create_var_last ();}
 
 void bdd___bdd_print (FILE *fp, BDDPTR f, char *s)
-  {return bdd_print (fp, f, s);}
+  {bdd_print (fp, f, s);}
 
-void bdd___bdd_quit (void) {return bdd_quit ();}
+void bdd___bdd_quit (void) {bdd_quit ();}
 
 int bdd___bdd_nodes_alive (void) {return bdd_nodes_alive ();}
 
@@ -166,7 +166,7 @@ BDDPTR bdd___bdd_subst_par_list (BDD_LIST f_list, BDD_LIST vars, BDDPTR g)
 {return (BDDPTR) bdd_subst_par_list (f_list, vars, g);}
 
 void bdd___bdd_free_vec (BDDPTR *f_vec, int size)
-  {return bdd_free_vec (f_vec, size);}
+  {bdd_free_vec (f_vec, size);}
 
 const char* bdd___bdd_get_output_string (int idx) {
   return (char*) bdd_get_output_string (idx);

--- a/src/BDD/mu_interface.h
+++ b/src/BDD/mu_interface.h
@@ -25,7 +25,7 @@ extern Term mu_mk_g_fixed_point (int relvar, Term fml1);
 extern Term mu_mk_rel_var_ (char *name);
 extern Formula mu_check_mk_bool_var (char *name);
 extern const char* get_mu_bool_var_name (int bdd_idx);
-extern LIST empty_list ();
+extern LIST empty_list (void);
 extern void pvs_mu_print_formula (Formula fml);
 extern void pvs_mu_print_term (Term t);
 

--- a/src/BDD/mu_table.c
+++ b/src/BDD/mu_table.c
@@ -80,13 +80,13 @@ Term mu___mu_mk_equiv_term (Term fml1, Term fml2)
 Term mu___mu_mk_implies_term (Term fml1, Term fml2)
   {return (Term) mu_mk_implies_term (fml1, fml2);}
 
-char* mu___get_mu_bool_var_name (bdd_idx)
+char* mu___get_mu_bool_var_name (int bdd_idx)
   {return (char *) get_mu_bool_var_name (bdd_idx);}
 
 LIST mu___append_cont(void *p, LIST list)
   {return (LIST) append_cont (p, list);}
 
-LIST mu___empty_list () {return (LIST) empty_list ();}
+LIST mu___empty_list (void) {return (LIST) empty_list ();}
 
 int mu___set_mu_warnings (int flag) {return set_mu_warnings (flag);}
  


### PR DESCRIPTION
These trivial fixes help with getting PVS compiled on ARM-based Macs.