### PR TITLE
Fix find-verb-char: use code-char instead of character for integer->char conversion

### DIFF
--- a/src/pp-tex.lisp
+++ b/src/pp-tex.lisp
@@ -706,7 +706,7 @@
 
 (defun find-verb-char (str)
   (dotimes (i 127)
-    (let ((ch (character i)))
+    (let ((ch (code-char i)))
       (when (and (graphic-char-p ch)
 		 (not (alphanumericp ch))
 		 (not (char= ch #\space))


### PR DESCRIPTION
I wasn't able to Install PVS with the latest version of SBCL (2.6.4). It looks like there was an issue with the char-to-int conversion in pp-tex.lisp; changing from `character` to `code-char` fixed the build problem for me.